### PR TITLE
rm secondary button color

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,6 +11,7 @@ Click below to head to the registration page.
 ```{button-link} https://www.eventsquid.com/event.cfm?id=23645
 :expand:
 :shadow:
+:color: light
 Sign Up Here!
 ```
 

--- a/index.md
+++ b/index.md
@@ -11,7 +11,6 @@ Click below to head to the registration page.
 ```{button-link} https://www.eventsquid.com/event.cfm?id=23645
 :expand:
 :shadow:
-:color: secondary
 Sign Up Here!
 ```
 


### PR DESCRIPTION
Specify color button to "light" instead of "secondary" renders better in light and dark mode
<img width="897" alt="Screenshot 2024-05-14 at 11 33 38 AM" src="https://github.com/ProjectPythia/pythia-cookoff-2024/assets/46687291/668c82ad-324b-472e-b3eb-74ee369aeb56">
<img width="913" alt="Screenshot 2024-05-14 at 11 33 45 AM" src="https://github.com/ProjectPythia/pythia-cookoff-2024/assets/46687291/cd41582e-b2de-4784-ae8a-dbc848b6136c">

I still want to fix something in the theme because this issue occurs elsewhere (such as the contributor's guide) but this is a quick fix to make the sign up visible!

<img width="1096" alt="Screenshot 2024-05-14 at 11 13 35 AM" src="https://github.com/ProjectPythia/pythia-cookoff-2024/assets/46687291/8520acb7-4ba4-4f2d-bb43-ce92a06a7a07">
